### PR TITLE
Fixed #4 - avoid generating empty fields in JSON outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+local/

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+c=$1
+
+case $c in
+"asn-only")
+	./local/parse --threshold 624 --samples 3 \
+		--eventout "../out/results_2021-03-11.01.2.json" \
+		--pcap "../data/2021-03-11.01.pcap.gz" \
+		--asnin "../data/GeoLite2-ASN.mmdb"
+	echo "asn only"
+	cat "../out/results_2021-03-11.01.2.json" | python3 -m json.tool > "../out/pretty_2021-03-11.01.2.json"
+;;
+"geo-only")
+	./local/parse --threshold 624 --samples 3 \
+		--eventout "../out/results_2021-03-11.01.2.json" \
+		--pcap "../data/2021-03-11.01.pcap.gz" \
+		--geoin "../data/GeoLite2-City.mmdb"
+	echo "geo only"
+	cat "../out/results_2021-03-11.01.2.json" | python3 -m json.tool > "../out/pretty_2021-03-11.01.2.json"
+;;
+"pfx2as-only")
+	./local/parse --threshold 624 --samples 3 \
+		--eventout "../out/results_2021-03-11.01.2.json" \
+		--pcap "../data/2021-03-11.01.pcap.gz" \
+		--pfx2asin "../data/routeviews-rv2-20201201-1200.pfx2as.gz"
+	echo "pfx2as only"
+	cat "../out/results_2021-03-11.01.2.json" | python3 -m json.tool > "../out/pretty_2021-03-11.01.2.json"
+;;
+"all")
+	./local/parse --threshold 624 --samples 3 \
+		--eventout "../out/results_2021-03-11.01.2.json" \
+		--pcap "../data/2021-03-11.01.pcap.gz" \
+		--asnin "../data/GeoLite2-ASN.mmdb" \
+		--geoin "../data/GeoLite2-City.mmdb" \
+		--pfx2asin "../data/routeviews-rv2-20201201-1200.pfx2as.gz"
+	echo "all flags present"
+	cat "../out/results_2021-03-11.01.2.json" | python3 -m json.tool > "../out/pretty_2021-03-11.01.2.json"
+;;
+"basic")
+	./local/parse --threshold 624 --samples 3 \
+		--eventout "../out/results_2021-03-11.01.2.json" \
+		--pcap "../data/2021-03-11.01.pcap.gz"
+	echo "basic usage"
+
+	cat "../out/results_2021-03-11.01.2.json" | python3 -m json.tool > "../out/pretty_2021-03-11.01.2.json"
+;;
+"v4-large")
+	./local/parse --threshold 624 --samples 3 \
+		--eventout "../out/results_2005-11-01.12.2.json" \
+		--pcap "../data/2005-11-01.12.pcap.gz" \
+		--asnin "../data/GeoLite2-ASN.mmdb" \
+		--geoin "../data/GeoLite2-City.mmdb" \
+		--pfx2asin "../data/routeviews-oix-20051029-1200.pfx2as.gz"
+	echo "ipv4 large"
+	cat "../out/results_2005-11-01.12.2.json" | python3 -m json.tool > "../out/pretty_2005-11-01.12.2.json"
+;;
+esac
+


### PR DESCRIPTION
This PR is about not displaying a certain field (country, city, asn, etc.) in the JSON output when the corresponding flag was not present. This was done by using the feature of pointers such that, when the pointers are written to a JSON file, they will be ignored if they have a value of `nil`. Otherwise, the field key will be created, and the value will be written into the entry. 

This modification aims to improve the readability of the output and reduce the cost of uploading JSON files to BigQuery.